### PR TITLE
Linear solver based on Resolve

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "linsys/external/ReSolve"]
+	path = linsys/external/ReSolve
+	url = git@github.com:ORNL/ReSolve.git

--- a/linsys/resolve/direct/private.cpp
+++ b/linsys/resolve/direct/private.cpp
@@ -1,0 +1,183 @@
+#include "private.hpp"
+
+#include <iostream>
+
+#include <resolve/matrix/Csr.hpp>
+#include <resolve/matrix/Csc.hpp>
+#include <resolve/vector/Vector.hpp>
+#include <resolve/LinSolverDirectKLU.hpp>
+#include <resolve/LinSolverDirectKLU.hpp>
+#include <resolve/LinSolverDirectRocSolverRf.hpp>
+#include <resolve/workspace/LinAlgWorkspace.hpp>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  const char *scs_get_lin_sys_method()
+  {
+    return "hip-ReSolve-direct";
+  }
+
+  void scs_free_lin_sys_work(ScsLinSysWork *p)
+  {
+    if (p == NULL)
+      return;
+
+    // Free memory owned by ReSolve
+    delete p->mat_A;
+    delete p->Rf;
+    delete p->vec_x;
+    delete p->vec_rhs;
+
+    // Free the matrix kkt data
+    if (p->kkt)
+      SCS(cs_spfree)
+    (p->kkt);
+
+    // Free host-side arrays used for updates
+    if (p->diag_r_idxs)
+      scs_free(p->diag_r_idxs);
+    if (p->diag_p)
+      scs_free(p->diag_p);
+
+    // Finally, free the work struct itself
+    scs_free(p);
+  }
+
+  scs_int __initialize_work(ScsLinSysWork *work)
+  {
+    // initialize ReSolve members of work:
+
+    int nnz = work->kkt->p[work->kkt->n]; // The last element of A->p gives the number of non-zeros
+    work->mat_A = new ReSolve::matrix::Csr(work->kkt->n, work->kkt->m, nnz);
+    work->mat_A->setMatrixData(work->kkt->p, work->kkt->i, work->kkt->x, ReSolve::memory::HOST);
+
+    // mat_A is CSC, symmetric, non-expanded
+    work->mat_A->setSymmetric(true);
+    work->mat_A->setExpanded(false);
+    work->mat_A->syncData(ReSolve::memory::DEVICE);
+
+    work->vec_x = new ReSolve::vector::Vector(work->mat_A->getNumRows());
+    work->vec_x->setToConst(1.0, ReSolve::memory::HOST);
+    work->vec_rhs = new ReSolve::vector::Vector(work->mat_A->getNumRows());
+    work->vec_rhs->setToConst(1.0, ReSolve::memory::HOST);
+
+    ReSolve::LinAlgWorkspaceHIP *workspace_HIP = new ReSolve::LinAlgWorkspaceHIP;
+    workspace_HIP->initializeHandles();
+    work->Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
+
+    // we start with KLU to setup work->Rf in a moment
+    ReSolve::LinSolverDirectKLU *KLU = new ReSolve::LinSolverDirectKLU;
+    scs_int status;
+    status = KLU->setup(work->mat_A);
+    std::cout << "KLU analysis status: " << status << std::endl;
+    status = KLU->factorize();
+    std::cout << "KLU factorization status: " << status << std::endl;
+    status = KLU->solve(work->vec_rhs, work->vec_x);
+    std::cout << "KLU solve status: " << status << std::endl;
+
+    ReSolve::matrix::Csc *L = (ReSolve::matrix::Csc *)KLU->getLFactor();
+    ReSolve::matrix::Csc *U = (ReSolve::matrix::Csc *)KLU->getUFactor();
+    ReSolve::index_type *P = KLU->getPOrdering();
+    ReSolve::index_type *Q = KLU->getQOrdering();
+
+    // finally let's setup work->Rf and prepare the factorisation!
+    status = work->Rf->setup(work->mat_A, L, U, P, Q, work->vec_rhs);
+    std::cout << "rocsolver rf refactorization status: " << status << std::endl;
+    status = work->Rf->refactorize();
+    return status;
+  }
+
+  ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
+                                       const scs_float *diag_r)
+  {
+    // ScsLinSysWork *p = scs_calloc(1, sizeof(ScsLinSysWork));
+    ScsLinSysWork *p = new ScsLinSysWork();
+
+    p->n = A->n;
+    p->m = A->m;
+    scs_int n_plus_m = p->n + p->m;
+
+    p->diag_r_idxs = (scs_int *)scs_calloc(n_plus_m, sizeof(scs_int));
+    p->diag_p = (scs_float *)scs_calloc(p->n, sizeof(scs_float));
+
+    // p->kkt is CSC in lower triangular form; this is equivalen to upper CSR
+    p->kkt = SCS(form_kkt)(A, P, p->diag_p, diag_r, p->diag_r_idxs, 0);
+    if (!(p->kkt))
+    {
+      scs_printf("Error in forming KKT matrix");
+      scs_free_lin_sys_work(p);
+      return SCS_NULL;
+    }
+
+    int status;
+    status = __initialize_work(p);
+
+    if (status == 0)
+    {
+      return p;
+    }
+    else
+    {
+      scs_printf("error in factorisation: %d", (int)status);
+      scs_free_lin_sys_work(p);
+      return SCS_NULL;
+    }
+  }
+
+  /* Returns solution to linear system Ax = b with solution stored in b */
+  scs_int scs_solve_lin_sys(ScsLinSysWork *p, scs_float *b, const scs_float *ws,
+                            scs_float tol)
+  {
+    // TODO: tol is ignored for now
+    if (p == NULL || b == NULL || ws == NULL)
+    {
+      return -1; // Error: invalid input
+    }
+
+    // copies data to device
+    p->vec_rhs->update(b, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    p->vec_x->update(const_cast<ReSolve::real_type *>(ws), ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+
+    int status;
+    status = p->Rf->solve(p->vec_rhs, p->vec_x);
+    std::cout << "rocsolver rf solve status: " << status << std::endl;
+
+    // Copy the solution back to the host
+    p->vec_x->deepCopyVectorData(b, ReSolve::memory::HOST);
+
+    return (scs_int)status;
+  }
+
+  /* Update factorization when R changes */
+  void scs_update_lin_sys_diag_r(ScsLinSysWork *p, const scs_float *diag_r)
+  {
+    scs_int i;
+
+    for (i = 0; i < p->n; ++i)
+    {
+      /* top left is R_x + P, bottom right is -R_y */
+      p->kkt->x[p->diag_r_idxs[i]] = p->diag_p[i] + diag_r[i];
+    }
+    for (i = p->n; i < p->n + p->m; ++i)
+    {
+      /* top left is R_x + P, bottom right is -R_y */
+      p->kkt->x[p->diag_r_idxs[i]] = -diag_r[i];
+    }
+
+    p->mat_A->updateValues(p->kkt->x, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+
+    int status;
+    status = p->Rf->refactorize();
+    if (status != 0)
+    {
+      scs_printf("Error in Re-factorization when updating: %d.\n", (int)status);
+      scs_free_lin_sys_work(p);
+    }
+  }
+
+#ifdef __cplusplus
+}
+#endif

--- a/linsys/resolve/direct/private.cpp
+++ b/linsys/resolve/direct/private.cpp
@@ -20,63 +20,65 @@ extern "C"
     return "hip-ReSolve-direct";
   }
 
-  void scs_free_lin_sys_work(ScsLinSysWork *p)
+  void scs_free_lin_sys_work(ScsLinSysWork *work)
   {
-    if (p == NULL)
+    if (work == NULL)
       return;
 
     // Free memory owned by ReSolve
-    delete p->mat_A;
-    delete p->Rf;
-    delete p->vec_x;
-    delete p->vec_rhs;
+    delete work->mat_A;
+    delete work->Rf;
+    delete work->vec_x;
+    delete work->vec_rhs;
 
     // Free the matrix kkt data
-    if (p->kkt)
-      SCS(cs_spfree)
-    (p->kkt);
+    if (work->kkt)
+      SCS(cs_spfree)(work->kkt);
 
     // Free host-side arrays used for updates
-    if (p->diag_r_idxs)
-      scs_free(p->diag_r_idxs);
-    if (p->diag_p)
-      scs_free(p->diag_p);
+    if (work->diag_r_idxs)
+      scs_free(work->diag_r_idxs);
+    if (work->diag_p)
+      scs_free(work->diag_p);
 
     // Finally, free the work struct itself
-    scs_free(p);
+    scs_free(work);
   }
 
   scs_int __initialize_work(ScsLinSysWork *work)
   {
     // initialize ReSolve members of work:
-
-    int nnz = work->kkt->p[work->kkt->n]; // The last element of A->p gives the number of non-zeros
-    work->mat_A = new ReSolve::matrix::Csr(work->kkt->n, work->kkt->m, nnz);
-    work->mat_A->setMatrixData(work->kkt->p, work->kkt->i, work->kkt->x, ReSolve::memory::HOST);
-
-    // mat_A is CSC, symmetric, non-expanded
-    work->mat_A->setSymmetric(true);
-    work->mat_A->setExpanded(false);
+    int nnz = work->kkt->p[work->kkt->n]; // The last element of A->work gives the number of non-zeros
+    // the matrix A is CSC, symmetric and not expanded
+    work->mat_A = new ReSolve::matrix::Csr(
+      work->kkt->n, work->kkt->m, nnz, true, false);
+    work->mat_A->setDataPointers(
+      work->kkt->p, work->kkt->i, work->kkt->x, ReSolve::memory::HOST);
     work->mat_A->syncData(ReSolve::memory::DEVICE);
 
-    work->vec_x = new ReSolve::vector::Vector(work->mat_A->getNumRows());
-    work->vec_x->setToConst(1.0, ReSolve::memory::HOST);
     work->vec_rhs = new ReSolve::vector::Vector(work->mat_A->getNumRows());
-    work->vec_rhs->setToConst(1.0, ReSolve::memory::HOST);
+    work->vec_rhs->allocate(ReSolve::memory::DEVICE);
+    // work->vec_rhs->allocate(ReSolve::memory::HOST);
 
-    ReSolve::LinAlgWorkspaceHIP *workspace_HIP = new ReSolve::LinAlgWorkspaceHIP;
-    workspace_HIP->initializeHandles();
-    work->Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
+    work->vec_x = new ReSolve::vector::Vector(work->mat_A->getNumRows());
+    work->vec_x->allocate(ReSolve::memory::DEVICE);
+    // work->vec_x->allocate(ReSolve::memory::HOST);
 
-    // we start with KLU to setup work->Rf in a moment
+    // we start with KLU
     ReSolve::LinSolverDirectKLU *KLU = new ReSolve::LinSolverDirectKLU;
     scs_int status;
     status = KLU->setup(work->mat_A);
-    std::cout << "KLU analysis status: " << status << std::endl;
+    if (status != 0){
+      scs_printf("Error in KLU setup: %d\n", (int)status);
+    }
+    status = KLU->analyze();
+    if (status != 0){
+      scs_printf("Error in KLU analyze: %d\n", (int)status);
+    }
     status = KLU->factorize();
-    std::cout << "KLU factorization status: " << status << std::endl;
-    status = KLU->solve(work->vec_rhs, work->vec_x);
-    std::cout << "KLU solve status: " << status << std::endl;
+    if (status != 0){
+      scs_printf("Error in KLU factorization: %d\n", (int)status);
+    }
 
     ReSolve::matrix::Csc *L = (ReSolve::matrix::Csc *)KLU->getLFactor();
     ReSolve::matrix::Csc *U = (ReSolve::matrix::Csc *)KLU->getUFactor();
@@ -84,45 +86,58 @@ extern "C"
     ReSolve::index_type *Q = KLU->getQOrdering();
 
     // finally let's setup work->Rf and prepare the factorisation!
+    ReSolve::LinAlgWorkspaceHIP *workspace_HIP = new ReSolve::LinAlgWorkspaceHIP;
+    workspace_HIP->initializeHandles();
+    work->Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
+
     status = work->Rf->setup(work->mat_A, L, U, P, Q, work->vec_rhs);
-    std::cout << "rocsolver rf refactorization status: " << status << std::endl;
+    if (status != 0)
+    {
+      scs_printf("Error in ReSolve Rf setup: %d\n", (int)status);
+      return status;
+    }
     status = work->Rf->refactorize();
+    if (status != 0)
+    {
+      scs_printf("Error in ReSolve Rf refactorization: %d\n", (int)status);
+      return status;
+    }
     return status;
   }
 
   ScsLinSysWork *scs_init_lin_sys_work(const ScsMatrix *A, const ScsMatrix *P,
                                        const scs_float *diag_r)
   {
-    // ScsLinSysWork *p = scs_calloc(1, sizeof(ScsLinSysWork));
-    ScsLinSysWork *p = new ScsLinSysWork();
+    // ScsLinSysWork *work = scs_calloc(1, sizeof(ScsLinSysWork));
+    ScsLinSysWork *work = new ScsLinSysWork();
 
-    p->n = A->n;
-    p->m = A->m;
-    scs_int n_plus_m = p->n + p->m;
+    work->n = A->n;
+    work->m = A->m;
+    scs_int n_plus_m = work->n + work->m;
 
-    p->diag_r_idxs = (scs_int *)scs_calloc(n_plus_m, sizeof(scs_int));
-    p->diag_p = (scs_float *)scs_calloc(p->n, sizeof(scs_float));
+    work->diag_r_idxs = (scs_int *)scs_calloc(n_plus_m, sizeof(scs_int));
+    work->diag_p = (scs_float *)scs_calloc(work->n, sizeof(scs_float));
 
     // p->kkt is CSC in lower triangular form; this is equivalen to upper CSR
-    p->kkt = SCS(form_kkt)(A, P, p->diag_p, diag_r, p->diag_r_idxs, 0);
-    if (!(p->kkt))
+    work->kkt = SCS(form_kkt)(A, P, work->diag_p, diag_r, work->diag_r_idxs, 0);
+    if (!(work->kkt))
     {
       scs_printf("Error in forming KKT matrix");
-      scs_free_lin_sys_work(p);
+      scs_free_lin_sys_work(work);
       return SCS_NULL;
     }
 
     int status;
-    status = __initialize_work(p);
+    status = __initialize_work(work);
 
     if (status == 0)
     {
-      return p;
+      return work;
     }
     else
     {
       scs_printf("error in factorisation: %d", (int)status);
-      scs_free_lin_sys_work(p);
+      scs_free_lin_sys_work(work);
       return SCS_NULL;
     }
   }
@@ -132,21 +147,26 @@ extern "C"
                             scs_float tol)
   {
     // TODO: tol is ignored for now
-    if (p == NULL || b == NULL || ws == NULL)
-    {
-      return -1; // Error: invalid input
-    }
 
     // copies data to device
-    p->vec_rhs->update(b, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-    p->vec_x->update(const_cast<ReSolve::real_type *>(ws), ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    // std::cout << "scs_solve_lin_sys: copying data to device" << std::endl;
+    p->vec_rhs->copyDataFrom(b, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    // p->vec_rhs->syncData(ReSolve::memory::DEVICE);
+    // std::cout << "scs_solve_lin_sys: vec_rhs copied" << std::endl;
+    p->vec_x->copyDataFrom(ws, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    // p->vec_x->syncData(ReSolve::memory::DEVICE);
+    // std::cout << "scs_solve_lin_sys: vec_x copied" << std::endl;
 
-    int status;
-    status = p->Rf->solve(p->vec_rhs, p->vec_x);
-    std::cout << "rocsolver rf solve status: " << status << std::endl;
+    int status = p->Rf->solve(p->vec_rhs, p->vec_x);
+    if (status != 0) {
+      scs_printf("Error in ReSolve Rf solve: %d\n", (int)status);
+      return status;
+    }
 
     // Copy the solution back to the host
-    p->vec_x->deepCopyVectorData(b, ReSolve::memory::HOST);
+    // std::cout << "scs_solve_lin_sys: copying solution back to host" << std::endl;
+    p->vec_x->copyDataTo(b, ReSolve::memory::DEVICE);
+    // std::cout << "scs_solve_lin_sys: solution copied back to host" << std::endl;
 
     return (scs_int)status;
   }
@@ -167,7 +187,8 @@ extern "C"
       p->kkt->x[p->diag_r_idxs[i]] = -diag_r[i];
     }
 
-    p->mat_A->updateValues(p->kkt->x, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    p->mat_A->setValuesPointer(p->kkt->x, ReSolve::memory::HOST);
+    p->mat_A->syncData(ReSolve::memory::DEVICE);
 
     int status;
     status = p->Rf->refactorize();

--- a/linsys/resolve/direct/private.cpp
+++ b/linsys/resolve/direct/private.cpp
@@ -2,12 +2,6 @@
 
 #include <iostream>
 
-#include <resolve/matrix/Csr.hpp>
-#include <resolve/matrix/Csc.hpp>
-#include <resolve/vector/Vector.hpp>
-#include <resolve/LinSolverDirectKLU.hpp>
-#include <resolve/LinSolverDirectKLU.hpp>
-#include <resolve/LinSolverDirectRocSolverRf.hpp>
 #include <resolve/workspace/LinAlgWorkspace.hpp>
 
 #ifdef __cplusplus
@@ -17,7 +11,7 @@ extern "C"
 
   const char *scs_get_lin_sys_method()
   {
-    return "hip-ReSolve-direct";
+    return "hip-ReSolve-KLU-rocsolverrf";
   }
 
   void scs_free_lin_sys_work(ScsLinSysWork *work)
@@ -27,7 +21,7 @@ extern "C"
 
     // Free memory owned by ReSolve
     delete work->mat_A;
-    delete work->Rf;
+    delete work->workspace_hip;
     delete work->vec_x;
     delete work->vec_rhs;
 
@@ -47,61 +41,81 @@ extern "C"
 
   scs_int __initialize_work(ScsLinSysWork *work)
   {
+    work->workspace_hip = new ReSolve::LinAlgWorkspaceHIP;
+    work->workspace_hip->initializeHandles();
+
+    work->solver = new ReSolve::SystemSolver(work->workspace_hip,
+                                  "klu", // factorization
+                                  "rocsolverrf", // refactorization
+                                  "rocsolverrf", // triangular solve
+                                  "none", // preconditioner (always 'none' here)
+                                  "none"); // iterative refinement
+
+    // solver.setRefinementMethod("fgmres", "cgs2");
+    // solver.getIterativeSolver().setCliParam("restart", "100");
+    // solver.getIterativeSolver().setMaxit(200);
+
     // initialize ReSolve members of work:
     int nnz = work->kkt->p[work->kkt->n]; // The last element of A->work gives the number of non-zeros
-    // the matrix A is CSC, symmetric and not expanded
+    // The work->KKT matrix is CSC (lower triangular is stored only)
+    // by symmetry this is CSR (upper-triangular is stored only)
+    // symmetric and not expanded
     work->mat_A = new ReSolve::matrix::Csr(
       work->kkt->n, work->kkt->m, nnz, true, false);
-    work->mat_A->setDataPointers(
-      work->kkt->p, work->kkt->i, work->kkt->x, ReSolve::memory::HOST);
+    // work->mat_A->setDataPointers(
+    //   work->kkt->p, work->kkt->i, work->kkt->x, ReSolve::memory::HOST);
+
+    work->mat_A->allocateMatrixData(ReSolve::memory::HOST);
+    work->mat_A->copyDataFrom(
+      work->kkt->p, work->kkt->i, work->kkt->x, ReSolve::memory::HOST,
+      ReSolve::memory::HOST);
+    work->mat_A->allocateMatrixData(ReSolve::memory::DEVICE);
     work->mat_A->syncData(ReSolve::memory::DEVICE);
+
+    work->mat_A->print(std::cout, 1);
 
     work->vec_rhs = new ReSolve::vector::Vector(work->mat_A->getNumRows());
     work->vec_rhs->allocate(ReSolve::memory::DEVICE);
-    // work->vec_rhs->allocate(ReSolve::memory::HOST);
+    work->vec_rhs->allocate(ReSolve::memory::HOST);
+    work->vec_rhs->setToConst(1.0, ReSolve::memory::DEVICE);
+    work->vec_rhs->syncData(ReSolve::memory::HOST);
 
-    work->vec_x = new ReSolve::vector::Vector(work->mat_A->getNumRows());
+    work->vec_x = new ReSolve::vector::Vector(work->mat_A->getNumColumns());
     work->vec_x->allocate(ReSolve::memory::DEVICE);
-    // work->vec_x->allocate(ReSolve::memory::HOST);
+    work->vec_x->allocate(ReSolve::memory::HOST);
+    work->vec_x->setToConst(1.0, ReSolve::memory::DEVICE);
+    work->vec_x->syncData(ReSolve::memory::HOST);
 
-    // we start with KLU
-    ReSolve::LinSolverDirectKLU *KLU = new ReSolve::LinSolverDirectKLU;
     scs_int status;
-    status = KLU->setup(work->mat_A);
-    if (status != 0){
-      scs_printf("Error in KLU setup: %d\n", (int)status);
-    }
-    status = KLU->analyze();
-    if (status != 0){
-      scs_printf("Error in KLU analyze: %d\n", (int)status);
-    }
-    status = KLU->factorize();
-    if (status != 0){
-      scs_printf("Error in KLU factorization: %d\n", (int)status);
-    }
-
-    ReSolve::matrix::Csc *L = (ReSolve::matrix::Csc *)KLU->getLFactor();
-    ReSolve::matrix::Csc *U = (ReSolve::matrix::Csc *)KLU->getUFactor();
-    ReSolve::index_type *P = KLU->getPOrdering();
-    ReSolve::index_type *Q = KLU->getQOrdering();
-
-    // finally let's setup work->Rf and prepare the factorisation!
-    ReSolve::LinAlgWorkspaceHIP *workspace_HIP = new ReSolve::LinAlgWorkspaceHIP;
-    workspace_HIP->initializeHandles();
-    work->Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
-
-    status = work->Rf->setup(work->mat_A, L, U, P, Q, work->vec_rhs);
+    status = work->solver->setMatrix(work->mat_A);
     if (status != 0)
     {
-      scs_printf("Error in ReSolve Rf setup: %d\n", (int)status);
+      scs_printf("Error in ReSolve solver setMatrix: %d\n", (int)status);
       return status;
     }
-    status = work->Rf->refactorize();
+
+    status = work->solver->analyze();
     if (status != 0)
     {
-      scs_printf("Error in ReSolve Rf refactorization: %d\n", (int)status);
+      scs_printf("Error in ReSolve solver analyze: %d\n", (int)status);
       return status;
     }
+    status = work->solver->factorize();
+    if (status != 0)
+    {
+      scs_printf("Error in ReSolve solver factorize: %d\n", (int)status);
+      return status;
+    }
+    // Now prepare the Rf solver
+    status = work->solver->refactorizationSetup();
+    status = work->solver->refactorize();
+    if (status != 0)
+    {
+      scs_printf("Error in ReSolve Re-factorization: %d\n", (int)status);
+      return status;
+    }
+    scs_printf("ReSolve solver initialized successfully.\n");
+
     return status;
   }
 
@@ -136,7 +150,7 @@ extern "C"
     }
     else
     {
-      scs_printf("error in factorisation: %d", (int)status);
+      scs_printf("error in initialization: %d", (int)status);
       scs_free_lin_sys_work(work);
       return SCS_NULL;
     }
@@ -151,15 +165,18 @@ extern "C"
     // copies data to device
     // std::cout << "scs_solve_lin_sys: copying data to device" << std::endl;
     p->vec_rhs->copyDataFrom(b, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    // std::cout << "rhs_size: " << p->vec_rhs->getSize() << std::endl;
+
     // p->vec_rhs->syncData(ReSolve::memory::DEVICE);
     // std::cout << "scs_solve_lin_sys: vec_rhs copied" << std::endl;
-    p->vec_x->copyDataFrom(ws, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    // std::cout << "vec_x size: " << p->vec_x->getSize() << std::endl;
+    // p->vec_x->copyDataFrom(b, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     // p->vec_x->syncData(ReSolve::memory::DEVICE);
     // std::cout << "scs_solve_lin_sys: vec_x copied" << std::endl;
 
-    int status = p->Rf->solve(p->vec_rhs, p->vec_x);
+    int status = p->solver->solve(p->vec_rhs, p->vec_x);
     if (status != 0) {
-      scs_printf("Error in ReSolve Rf solve: %d\n", (int)status);
+      scs_printf("Error in ReSolve solve: %d\n", (int)status);
       return status;
     }
 
@@ -187,11 +204,10 @@ extern "C"
       p->kkt->x[p->diag_r_idxs[i]] = -diag_r[i];
     }
 
-    p->mat_A->setValuesPointer(p->kkt->x, ReSolve::memory::HOST);
+    p->mat_A->copyValues(p->kkt->x, ReSolve::memory::HOST, ReSolve::memory::HOST);
     p->mat_A->syncData(ReSolve::memory::DEVICE);
 
-    int status;
-    status = p->Rf->refactorize();
+    int status = p->solver->refactorize();
     if (status != 0)
     {
       scs_printf("Error in Re-factorization when updating: %d.\n", (int)status);

--- a/linsys/resolve/direct/private.hpp
+++ b/linsys/resolve/direct/private.hpp
@@ -1,0 +1,36 @@
+#ifndef PRIV_H_GUARD
+#define PRIV_H_GUARD
+
+#include "csparse.h"
+#include "linsys.h"
+#include <resolve/matrix/Csr.hpp>
+#include <resolve/vector/Vector.hpp>
+#include <resolve/LinSolverDirectRocSolverRf.hpp>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  struct SCS_LIN_SYS_WORK
+  {
+    // Host:
+    ScsMatrix *kkt; /* Upper triangular KKT matrix (in CSR format) */
+    scs_int n;      /* number of QP variables */
+    scs_int m;      /* number of QP constraints */
+
+    /* These are required for matrix updates */
+    scs_int *diag_r_idxs; /* indices where R appears */
+    scs_float *diag_p;    /* Diagonal values of P */
+
+    ReSolve::LinSolverDirectRocSolverRf *Rf;
+    ReSolve::matrix::Csr *mat_A;
+    ReSolve::vector::Vector *vec_x;
+    ReSolve::vector::Vector *vec_rhs;
+  };
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/linsys/resolve/direct/private.hpp
+++ b/linsys/resolve/direct/private.hpp
@@ -5,7 +5,7 @@
 #include "linsys.h"
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/vector/Vector.hpp>
-#include <resolve/LinSolverDirectRocSolverRf.hpp>
+#include <resolve/SystemSolver.hpp>
 
 #ifdef __cplusplus
 extern "C"
@@ -23,10 +23,11 @@ extern "C"
     scs_int *diag_r_idxs; /* indices where R appears */
     scs_float *diag_p;    /* Diagonal values of P */
 
-    ReSolve::LinSolverDirectRocSolverRf *Rf;
-    ReSolve::matrix::Csr *mat_A;
-    ReSolve::vector::Vector *vec_x;
-    ReSolve::vector::Vector *vec_rhs;
+    ReSolve::LinAlgWorkspaceHIP *workspace_hip; /* ReSolve workspace */
+    ReSolve::SystemSolver *solver; /* ReSolve system solver */
+    ReSolve::matrix::Csr *mat_A; /* ReSolve matrix A */
+    ReSolve::vector::Vector *vec_x; /* ReSolve vector x */
+    ReSolve::vector::Vector *vec_rhs; /* ReSolve vector rhs */
   };
 
 #ifdef __cplusplus

--- a/scs.mk
+++ b/scs.mk
@@ -72,6 +72,7 @@ GPUDIR = $(LINSYS)/gpu/direct
 GPUINDIR = $(LINSYS)/gpu/indirect
 MKLSRC = $(LINSYS)/mkl/direct
 HIPSRC = $(LINSYS)/hip/direct
+RESOLVESRC = $(LINSYS)/resolve/direct
 
 EXTSRC = $(LINSYS)/external
 
@@ -142,6 +143,10 @@ HIP_PATH = /opt/rocm
 HIPLDFLAGS = -L$(HIP_PATH)/lib -lamdhip64 -lhipsparse
 HIPCFLAGS = -D__$(HIP_PLATFORM)__ -I$(HIP_PATH)/include -Wno-extra-semi -Wno-strict-prototypes
 
+RESOLVE_PATH = $(EXTSRC)/ReSolve
+RESOLVE_LIBPATH = $(RESOLVE_PATH)/build/resolve
+RESOLVECFLAGS = -I$(HIP_PATH)/include -I/usr/include/suitesparse -Wno-unused-result -Wno-pedantic -Wno-strict-prototypes
+RESOLVELDFLAGS = -lstdc++ -L$(RESOLVE_LIBPATH) -lReSolve -L$(RESOLVE_LIBPATH)/matrix -lresolve_matrix -L$(RESOLVE_LIBPATH)/vector -lresolve_vector -L$(RESOLVE_LIBPATH)/workspace -lresolve_workspace
 ############ OPENMP: ############
 # set USE_OPENMP = 1 to allow openmp (multi-threaded matrix multiplies):
 # set the number of threads to, for example, 4 by entering the command:


### PR DESCRIPTION
@kswirydo here is something that at least compiles ;) (a great success of mine!)

Since I don't know how to deal with CMake I did this:

1) clone ReSolve to `linsys/external`
2) build it there (locally) into `ReSolve/build`
3) from the main scs directory run `make DLONG=0 USE_OPENMP=1 resolve`

What works:
* it compiles

What doesn't:
* it returns status 1 from KLU factorisation, then segfaults

```
export RESOLVE_LIBPATH="./linsys/external/ReSolve/build/resolve"
LD_LIBRARY_PATH=$RESOLVE_LIBPATH:$RESOLVE_LIBPATH/matrix:$RESOLVE_LIBPATH/vector:$RESOLVE_LIBPATH/workspace ./out/run_tests_resolve
```
```
*********************************************************
Running test: test_validation
Testing that SCS handles bad inputs correctly:
eps_abs tolerance must be positive
ERROR: Validation returned failure
Failure:could not initialize work
*********************************************************
Running test: degenerate
------------------------------------------------------------------
	       SCS v3.2.7 - Splitting Conic Solver
	(c) Brendan O'Donoghue, Stanford University, 2012
------------------------------------------------------------------
problem:  variables n: 2, constraints m: 4
cones: 	  l: linear vars: 4
settings: eps_abs: 1.0e-06, eps_rel: 1.0e-06, eps_infeas: 1.0e-09
	  alpha: 1.50, scale: 1.00e-01, adaptive_scale: 1
	  max_iters: 100000, normalize: 1, rho_x: 1.00e-06
	  acceleration_lookback: 10, acceleration_interval: 10
lin-sys:  hip-ReSolve-direct
	  nnz(A): 4, nnz(P): 2
KLU analysis status: 0
KLU factorization status: 1
[2]    505905 segmentation fault (core dumped)  LD_LIBRARY_PATH= ./out/run_tests_resolve
```

I have a few questions:
1. As we discussed symmetric CSC, non-expanded, lower triangle stored is equivalent to CSR, upper triangle stored. How to communicate to resolve that a `matrix::Csr *A` is symmetric, non-expanded, upper triangle stored? See https://github.com/kalmarek/scs/blob/mk/resolve/linsys/resolve/direct/private.cpp#L53-L60
3. What I understend is that `KLU` doesn't own the memory of `L, U, P Q` and I'm free to pass them to `Rf` and `delete KLU` afterwards? (I don't store the references to any of those, I just store
https://github.com/kalmarek/scs/blob/mk/resolve/linsys/resolve/direct/private.hpp#L26-L29

Here's the appropriate snippet: 
https://github.com/kalmarek/scs/blob/mk/resolve/linsys/resolve/direct/private.cpp#L65-L85